### PR TITLE
fixed division-by-zero in case of an empty model.

### DIFF
--- a/src/mc/IIC.cpp
+++ b/src/mc/IIC.cpp
@@ -380,7 +380,7 @@ namespace IIC {
     delete ev;
     model().constRelease(eat);
     // Choose number of threads.
-    unsigned nthreads = ceil((4000000)/modelSize);
+    unsigned nthreads = modelSize > 0 ? ceil((4000000)/modelSize) : thread_limit;
     nthreads = nthreads < thread_limit ? nthreads : thread_limit;
     unsigned long reorder_timeout = 1500*nthreads;
     // Push tactics at the front of the tactic queue in reverse order.


### PR DESCRIPTION
The commit fixes a potential division-by-zero in case modelSize = 0.

The problem is triggered, e.g., when the CTL property `AG( false )` is checked.